### PR TITLE
Feature/restartable ansible

### DIFF
--- a/roles/configure-os-security/tasks/ufw.yaml
+++ b/roles/configure-os-security/tasks/ufw.yaml
@@ -25,7 +25,7 @@
   ufw:
     direction: incoming
     policy: allow
-    port: "{{ ubuntu_common_ssh_port }}"
+    port: "{{ ubuntu_common_ssh_port | string }}"
     proto: tcp
   environment:
     PATH: /sbin:{{ ansible_env.PATH }}

--- a/roles/configure-os-security/tasks/ufw.yaml
+++ b/roles/configure-os-security/tasks/ufw.yaml
@@ -34,7 +34,7 @@
   ufw:
     direction: in
     rule: limit
-    port: "{{ ubuntu_common_ssh_port }}"
+    port: "{{ ubuntu_common_ssh_port | string }}"
     proto: tcp
   environment:
     PATH: /sbin:{{ ansible_env.PATH }}

--- a/roles/install-ansible/tasks/main.yaml
+++ b/roles/install-ansible/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Update and upgrade apt packages
-  become: true
+  become: yes
   apt:
     upgrade: yes
     update_cache: yes

--- a/roles/install-ansible/tasks/main.yaml
+++ b/roles/install-ansible/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: Update and upgrade apt packages
   become: yes
   apt:
-    upgrade: yes
+    upgrade: 'yes' # string required
     update_cache: yes
     cache_valid_time: 3600 
   

--- a/roles/install-e2a/tasks/main.yaml
+++ b/roles/install-e2a/tasks/main.yaml
@@ -12,6 +12,7 @@
   git:
     repo: "https://github.com/stereum-dev/ethereum2-ansible.git"
     dest: "{{ e2a_install_path }}"
+    force: yes
   become: yes
 
 - name: Change file ownership and group of clone

--- a/roles/install-e2ccc/tasks/main.yaml
+++ b/roles/install-e2ccc/tasks/main.yaml
@@ -12,6 +12,7 @@
   git:
     repo: "https://github.com/stereum-dev/ethereum2-control-center-cli.git"
     dest: "{{ e2ccc_install_path }}"
+    force: yes
   become: yes
 
 - name: Change file ownership and group of clone

--- a/roles/install-e2dc/tasks/main.yaml
+++ b/roles/install-e2dc/tasks/main.yaml
@@ -12,6 +12,7 @@
   git:
     repo: "https://github.com/stereum-dev/ethereum2-docker-compose.git"
     dest: "{{ install_e2dc_install_path }}"
+    force: yes
   become: yes
 
 - name: Change file ownership and group of clone


### PR DESCRIPTION
Sometimes "install" playbook fails. For example when there is a network issue downloading Docker images. In this case running "install" playbook again should finish installation correctly.

However, when cloning Stereum's repositories, Ansible failed due to local modifications from first run. Adding "force" flag safely ignores them (they will be reintroduced later in the playbook).