### PR TITLE
Prysm - checking wallet password 

### DIFF
--- a/roles/import-validator-keys-prysm/tasks/main.yaml
+++ b/roles/import-validator-keys-prysm/tasks/main.yaml
@@ -9,9 +9,16 @@
   pip:
     name: pexpect
 
+- name: get existing wallet password
+  command: "cat {{ e2dc_install_path }}//data/prysm/validator/passwords/wallet-password"
+  register: existing_password
+  become: yes
+  become_user: "{{ stereum_user }}"
+
 - name: Generate wallet password
   shell: uuidgen
-  register: wallet_password_gen
+  register: wallet_password_gen 
+  when: existing_password.sdtout == ""
 
 - name: Set wallet password
   copy:
@@ -19,6 +26,7 @@
     dest: "{{ e2dc_install_path }}//data/prysm/validator/passwords/wallet-password"
   become: yes
   become_user: "{{ stereum_user }}"
+  when: existing_password.sdtout == ""
 
 - name: Run import
   ansible.builtin.expect:  


### PR DESCRIPTION
if the wallet password exists, then use it to import validator account(s). If it doesn't exists, then create new random password for wallet
https://github.com/stereum-dev/ethereum2-ansible/issues/113