### PR TITLE
Lighthouse, Nimbus: listing imported validators

### DIFF
--- a/list-validator-accounts.yaml
+++ b/list-validator-accounts.yaml
@@ -24,4 +24,14 @@
         name: list-validator-keys-lodestar
       when: setup == "lodestar"
 
+    - name: List accounts lighthouse
+      include_role:
+        name: list-validator-keys-lighthouse
+      when: setup == "lighthouse"
+
+    - name: List accounts nimbus
+      include_role:
+        name: list-validator-keys-nimbus
+      when: setup == "nimbus"  
+
 # EOF

--- a/roles/delete-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/delete-validator-keys-lighthouse/tasks/main.yaml
@@ -6,25 +6,25 @@
 
 - name: Remove voting keystore path line
   ansible.builtin.lineinfile:
-    path: "{{ e2dc_install_path }}/wallets/validators/validator_definitions_test.yml"
+    path: "{{ e2dc_install_path }}/wallets/validators/validator_definitions.yml"
     regexp: '\/{{ validator_pubkey }}\/'
     state: absent
   become: yes
 
 - name: Remove related first line
-  command: sed -i 'N;s/.*\(\s*\n.*{{ validator_pubkey }}\)/\1/;P;D' validator_definitions_test.yml
+  command: sed -i 'N;s/.*\(\s*\n.*{{ validator_pubkey }}\)/\1/;P;D' validator_definitions.yml
   args:
     chdir: "{{ e2dc_install_path }}/wallets/validators/"
   become: yes
 
 - name: Remove rest of the related lines
-  command: "sed -i '/{{ validator_pubkey }}/,+3 d' validator_definitions_test.yml"
+  command: "sed -i '/{{ validator_pubkey }}/,+3 d' validator_definitions.yml"
   args:
     chdir: "{{ e2dc_install_path }}/wallets/validators/"
   become: yes
 
 - name: Remove empty lines 
-  command: "sed --in-place '/^$/d' validator_definitions_test.yml"
+  command: "sed --in-place '/^$/d' validator_definitions.yml"
   args:
     chdir: "{{ e2dc_install_path }}/wallets/validators/"
   become: yes

--- a/roles/import-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/import-validator-keys-lighthouse/tasks/main.yaml
@@ -41,4 +41,10 @@
   become: yes
   when: "'Skipping import of keystore for existing public key' in import_output.stdout"
 
+- name: error empty password
+  fail:
+    msg: "Password is empty!"
+  become: yes
+  when: import_output.stdout == ""
+
 # EOF

--- a/roles/import-validator-keys-lodestar/tasks/main.yaml
+++ b/roles/import-validator-keys-lodestar/tasks/main.yaml
@@ -25,4 +25,10 @@
   become: yes
   when: "'All validators are already imported' in import_output.stdout"
 
+- name: error empty password
+  fail:
+    msg: "Password is empty!"
+  become: yes
+  when: import_output.stdout == ""
+
 # EOF

--- a/roles/import-validator-keys-nimbus/tasks/main.yaml
+++ b/roles/import-validator-keys-nimbus/tasks/main.yaml
@@ -31,4 +31,10 @@
   become: yes
   when: "'The entered password was incorrect' in import_output.stdout"
 
+- name: error empty password
+  fail:
+    msg: "Password is empty!"
+  become: yes
+  when: import_output.stdout == ""
+
 # EOF

--- a/roles/import-validator-keys-prysm/tasks/main.yaml
+++ b/roles/import-validator-keys-prysm/tasks/main.yaml
@@ -41,4 +41,10 @@
   become: yes
   when: "'Password incorrect for key' in import_output.stdout"
 
+- name: error empty password
+  fail:
+    msg: "Password is empty!"
+  become: yes
+  when: import_output.stdout == ""
+
 # EOF

--- a/roles/list-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/list-validator-keys-lighthouse/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+- name: Run list validators
+  command: "ls {{ e2dc_install_path }}/wallets/validators"
+  args:
+    chdir: "{{ e2dc_install_path }}"
+  become: yes
+
+# EOF

--- a/roles/list-validator-keys-nimbus/tasks/main.yaml
+++ b/roles/list-validator-keys-nimbus/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+- name: Run list validators
+  command: "ls {{ e2dc_install_path }}/data/nimbus/validator/validators"
+  args:
+    chdir: "{{ e2dc_install_path }}"
+  become: yes
+
+# EOF


### PR DESCRIPTION
also checking empty password at importing some clients (lighthouse, lodestar, prysm and nimbus) 
issue: https://github.com/stereum-dev/ethereum2-ansible/issues/131