### PR TITLE
Lighthouse, Lodestar, Prysm, Nimbus: delete keystore file after "removing validator" 

### DIFF
--- a/export-config.yaml
+++ b/export-config.yaml
@@ -1,0 +1,46 @@
+---
+- hosts: stereumnodes
+  vars_files:
+    - /etc/stereum/ethereum2.yaml
+
+  tasks:
+    - name: Create directory for exporting config and keystore files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      loop:
+        - /tmp/exported-config/config
+        - /tmp/exported-config/keystore
+      become: yes
+
+    - name: Export config prysm
+      include_role:
+        name: export-config-prysm
+      when: setup == "prysm"
+
+    - name: Export config lodestar
+      include_role:
+        name: export-config-lodestar
+      when: setup == "lodestar"
+
+    - name: Export config lighthouse
+      include_role:
+        name: export-config-lighthouse
+      when: setup == "lighthouse"
+
+    - name: Export config nimbus
+      include_role:
+        name: export-config-nimbus
+      when: setup == "nimbus"
+
+    - name: Export config teku
+      include_role:
+        name: export-config-teku
+      when: setup == "teku"
+
+    - name: INFO
+      debug:
+        msg: "You will find the exported configuration here: '/tmp/exported-config'"
+      become: yes          
+
+# EOF

--- a/roles/delete-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/delete-validator-keys-lighthouse/tasks/main.yaml
@@ -35,7 +35,7 @@
   register: pubkey_without_0x
   become: yes
 
-- name: Remove keystore file form backup directory
+- name: Remove keystore file from backup directory
   shell: "grep -l {{ pubkey_without_0x.stdout_lines[0] }} * | xargs rm"
   args:
     chdir: "{{ e2dc_install_path }}/launchpad/keystore_backup"

--- a/roles/delete-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/delete-validator-keys-lighthouse/tasks/main.yaml
@@ -1,3 +1,4 @@
+---
 - name: Run delete validators directory
   ansible.builtin.file:
     path: "{{ e2dc_install_path }}/wallets/validators/{{ validator_pubkey }}"
@@ -28,3 +29,18 @@
   args:
     chdir: "{{ e2dc_install_path }}/wallets/validators/"
   become: yes
+
+- name: Separate 0x from public key
+  shell: "printf {{ validator_pubkey }} | tail -c 96"
+  args:
+    chdir: "{{ e2dc_install_path }}/launchpad/keystore_backup"
+  register: pubkey_without_0x
+  become: yes
+
+- name: Remove keystore file form backup directory
+  shell: "grep -l {{ pubkey_without_0x.stdout_lines[0] }} * | xargs rm"
+  args:
+    chdir: "{{ e2dc_install_path }}/launchpad/keystore_backup"
+  become: yes
+
+# EOF

--- a/roles/delete-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/delete-validator-keys-lighthouse/tasks/main.yaml
@@ -32,8 +32,6 @@
 
 - name: Separate 0x from public key
   shell: "printf {{ validator_pubkey }} | tail -c 96"
-  args:
-    chdir: "{{ e2dc_install_path }}/launchpad/keystore_backup"
   register: pubkey_without_0x
   become: yes
 

--- a/roles/delete-validator-keys-lodestar/tasks/main.yaml
+++ b/roles/delete-validator-keys-lodestar/tasks/main.yaml
@@ -1,3 +1,4 @@
+---
 - name: Run delete keystores directory
   ansible.builtin.file:
     path: "{{ e2dc_install_path }}/data/lodestar/validator/keystores/{{ validator_pubkey }}"
@@ -9,3 +10,16 @@
     path: "{{ e2dc_install_path }}/data/lodestar/validator/secrets/{{ validator_pubkey }}"
     state: absent
   become: yes
+
+- name: Separate 0x from public key
+  shell: "printf {{ validator_pubkey }} | tail -c 96"
+  register: pubkey_without_0x
+  become: yes
+
+- name: Remove keystore file from launchpad
+  shell: "grep -l {{ pubkey_without_0x.stdout_lines[0] }} * | xargs rm"
+  args:
+    chdir: "{{ e2dc_install_path }}/launchpad"
+  become: yes
+
+# EOF  

--- a/roles/delete-validator-keys-nimbus/tasks/main.yaml
+++ b/roles/delete-validator-keys-nimbus/tasks/main.yaml
@@ -1,3 +1,4 @@
+---
 - name: Run delete validators directory
   ansible.builtin.file:
     path: "{{ e2dc_install_path }}/data/nimbus/validator/validators/{{ validator_pubkey }}"
@@ -9,3 +10,16 @@
     path: "{{ e2dc_install_path }}/data/nimbus/validator/secrets/{{ validator_pubkey }}"
     state: absent
   become: yes
+
+- name: Separate 0x from public key
+  shell: "printf {{ validator_pubkey }} | tail -c 96"
+  register: pubkey_without_0x
+  become: yes
+
+- name: Remove keystore file from launchpad
+  shell: "grep -l {{ pubkey_without_0x.stdout_lines[0] }} * | xargs rm"
+  args:
+    chdir: "{{ e2dc_install_path }}/launchpad"
+  become: yes
+
+# EOF

--- a/roles/delete-validator-keys-prysm/tasks/main.yaml
+++ b/roles/delete-validator-keys-prysm/tasks/main.yaml
@@ -11,3 +11,16 @@
   become_user: "{{ stereum_user }}"
   ignore_errors: yes
   when: setups[setup].delete_account is defined
+
+- name: Separate 0x from public key
+  shell: "printf {{ validator_pubkey }} | tail -c 96"
+  register: pubkey_without_0x
+  become: yes
+
+- name: Remove keystore file from launchpad
+  shell: "grep -l {{ pubkey_without_0x.stdout_lines[0] }} * | xargs rm"
+  args:
+    chdir: "{{ e2dc_install_path }}/launchpad"
+  become: yes
+
+# EOF  

--- a/roles/export-config-lighthouse/tasks/main.yaml
+++ b/roles/export-config-lighthouse/tasks/main.yaml
@@ -6,11 +6,7 @@
   become: yes
 
 - name: Export keystore files
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/exported-config/keystore
-  with_fileglob:
-    - "{{ e2dc_install_path }}/launchpad/keystore_backup/keystore-*.json"
+  shell: "cp {{ e2dc_install_path }}/launchpad/keystore_backup/keystore-*.json /tmp/exported-config/keystore"
   become: yes
 
 - name: Set exported config file's permission

--- a/roles/export-config-lighthouse/tasks/main.yaml
+++ b/roles/export-config-lighthouse/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+- name: Export config - ethereum2.yaml file
+  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
+  args:
+    chdir: "/etc/stereum/"
+  become: yes
+
+- name: Export keystore files
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config/keystore
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore_backup/keystore-*.json"
+  become: yes
+
+- name: Set exported config file's permission
+  command: "chmod -R 755 /tmp/exported-config"
+  become: yes
+
+# EOF

--- a/roles/export-config-lodestar/tasks/main.yaml
+++ b/roles/export-config-lodestar/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+- name: Export config - ethereum2.yaml file
+  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
+  args:
+    chdir: "/etc/stereum/"
+  become: yes
+
+- name: Export keystore files
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config/keystore
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  become: yes
+
+- name: Set exported config file's permission
+  command: "chmod -R 755 /tmp/exported-config"
+  become: yes
+
+# EOF

--- a/roles/export-config-lodestar/tasks/main.yaml
+++ b/roles/export-config-lodestar/tasks/main.yaml
@@ -6,11 +6,7 @@
   become: yes
 
 - name: Export keystore files
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/exported-config/keystore
-  with_fileglob:
-    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config/keystore"
   become: yes
 
 - name: Set exported config file's permission

--- a/roles/export-config-nimbus/tasks/main.yaml
+++ b/roles/export-config-nimbus/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+- name: Export config - ethereum2.yaml file
+  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
+  args:
+    chdir: "/etc/stereum/"
+  become: yes
+
+- name: Export keystore files
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config/keystore
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  become: yes
+
+- name: Set exported config file's permission
+  command: "chmod -R 755 /tmp/exported-config"
+  become: yes
+
+# EOF

--- a/roles/export-config-nimbus/tasks/main.yaml
+++ b/roles/export-config-nimbus/tasks/main.yaml
@@ -6,11 +6,7 @@
   become: yes
 
 - name: Export keystore files
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/exported-config/keystore
-  with_fileglob:
-    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config/keystore"
   become: yes
 
 - name: Set exported config file's permission

--- a/roles/export-config-prysm/tasks/main.yaml
+++ b/roles/export-config-prysm/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+- name: Export config - ethereum2.yaml file
+  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
+  args:
+    chdir: "/etc/stereum/"
+  become: yes
+
+- name: Export keystore files
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config/keystore
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  become: yes
+
+- name: Set exported config file's permission
+  command: "chmod -R 755 /tmp/exported-config"
+  become: yes
+
+# EOF

--- a/roles/export-config-prysm/tasks/main.yaml
+++ b/roles/export-config-prysm/tasks/main.yaml
@@ -6,11 +6,7 @@
   become: yes
 
 - name: Export keystore files
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/exported-config/keystore
-  with_fileglob:
-    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config/keystore"
   become: yes
 
 - name: Set exported config file's permission

--- a/roles/export-config-teku/tasks/main.yaml
+++ b/roles/export-config-teku/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+- name: Export config - ethereum2.yaml file
+  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
+  args:
+    chdir: "/etc/stereum/"
+  become: yes
+
+- name: Export keystore files
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config/keystore
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  become: yes
+
+- name: Set exported config file's permission
+  command: "chmod -R 755 /tmp/exported-config"
+  become: yes
+
+# EOF

--- a/roles/export-config-teku/tasks/main.yaml
+++ b/roles/export-config-teku/tasks/main.yaml
@@ -6,11 +6,7 @@
   become: yes
 
 - name: Export keystore files
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/exported-config/keystore
-  with_fileglob:
-    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config/keystore"
   become: yes
 
 - name: Set exported config file's permission


### PR DESCRIPTION
Teku is already removing "deleted validator's keystore" file from launchpad directory.
It is necessary to exporting currently running config & validators  