### PR TITLE
Use private network address for docker address pool

### DIFF
--- a/roles/write-config/templates/ethereum2.yaml.j2
+++ b/roles/write-config/templates/ethereum2.yaml.j2
@@ -127,7 +127,7 @@ setups:
     overrides_path: compose-examples/teku-only/override-examples
 
 # docker settings
-docker_address_pool_base: 172.80.0.0/12
+docker_address_pool_base: 172.16.0.0/12
 docker_address_pool_size: 24
 
 


### PR DESCRIPTION
Currently, Docker address pool incorrectly uses public network address.

This makes certain part of Internet unavailable as well as causes problems with some firewall configurations. In particular this causes issues with Mullvad VPN which allows to access public internet addresses only via VPN interface. This way Mullvad VPN blocks communication with docker containers which prevents docker port forwarding to work.

This pull request changes docker address pool from publicly routable 172.80/12 address to private 172.16/12 address.