### PR TITLE
Allow docker to automatically choose network address

### DIFF
--- a/roles/install-docker/tasks/main.yaml
+++ b/roles/install-docker/tasks/main.yaml
@@ -7,14 +7,6 @@
   include_tasks: docker-ubuntu.yaml
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
-- name: Generate docker's daemon.json
-  template:
-    src: daemon.json.j2
-    dest: "/etc/docker/daemon.json"
-    owner: "root"
-    group: "root"
-    mode: 644
-
 - name: enable service docker
   systemd:
     name: docker

--- a/roles/install-docker/templates/daemon.json.j2
+++ b/roles/install-docker/templates/daemon.json.j2
@@ -1,5 +1,0 @@
-{
-  "default-address-pools":[
-    {"base":"{{ docker_address_pool_base }}","size":{{ docker_address_pool_size }}}
-  ]
-}

--- a/roles/write-config/templates/ethereum2.yaml.j2
+++ b/roles/write-config/templates/ethereum2.yaml.j2
@@ -126,9 +126,4 @@ setups:
     exit_account: teku-only/exit-account.yaml
     overrides_path: compose-examples/teku-only/override-examples
 
-# docker settings
-docker_address_pool_base: 172.80.0.0/12
-docker_address_pool_size: 24
-
-
 # EOF


### PR DESCRIPTION
Currently, Docker address pool incorrectly uses public network address.

This makes certain part of Internet unavailable as well as causes problems with some firewall configurations. In particular this causes issues with Mullvad VPN which allows to access public internet addresses only via VPN interface. This way Mullvad VPN blocks communication with docker containers which prevents docker port forwarding to work.

Stereum uses docker_address_pool_base and docker_address_pool_size variables to define docker's default-address-pools setting in daemon.json. If this setting is not defined docker uses dynamically generated address. This dynamically generated address takes into account networks already defined on target system, therefore for me seems superior for hardcoding the address and causing potential conflicts.

I grepped all Stereum repositories and noticed docker_address_pool_base and docker_address_pool_size is not used anywhere else. Therefore I propose to remove it entirely. This way docker network would use private and conflict resilient autogenerated address.