### PR TITLE
Fix graffiti for Lighthouse

### DIFF
--- a/roles/set-graffiti/tasks/main.yaml
+++ b/roles/set-graffiti/tasks/main.yaml
@@ -15,7 +15,7 @@
   lineinfile:
     path: "{{ e2dc_install_path }}/config/lighthouse/validator.env"
     regexp: '^GRAFFITI='
-    line: 'GRAFFITI="{{ e2dc_graffiti | default("stereum.net") }}"'
+    line: 'GRAFFITI={{ e2dc_graffiti | default("stereum.net") }}'
   when: setup == "lighthouse"
   become: yes
   become_user: "{{ stereum_user }}"


### PR DESCRIPTION
Set graffiti for Lighthouse without double quotes because quoting in docker compose env file is not supported.

From Docker Compose docs:

"The value of VAL is used as is and not modified at all. For example if the value is surrounded by quotes (as is often the case of shell variables), the quotes are included in the value passed to Compose."

https://docs.docker.com/compose/compose-file/compose-file-v3/