### PR TITLE
Fix always failing switch to portable Lighthouse version

### DIFF
--- a/roles/set-docker-tag/tasks/main.yaml
+++ b/roles/set-docker-tag/tasks/main.yaml
@@ -16,7 +16,7 @@
     path: "{{ e2dc_install_path }}/.env"
     regexp: '(LIGHTHOUSE_DOCKER_TAG=v[\d\.]*)(.*)'
     replace: '\1-portable\2'
-  when: setup == "lighthouse" and grep_adx_cpu_info.stdout == "0" and grep_portable_version == "0"
+  when: setup == "lighthouse" and grep_adx_cpu_info.stdout == "0" and grep_portable_version.stdout == "0"
   become: yes
 
 # EOF


### PR DESCRIPTION
This pull request broke setting docker tag for portable version of Lighthouse:
https://github.com/stereum-dev/ethereum2-ansible/pull/139

This PR fixes that.