### PR TITLE
multiclient's validator import

### DIFF
--- a/export-config.yaml
+++ b/export-config.yaml
@@ -41,10 +41,12 @@
         update_cache: yes
         name:
           - python3-pip
+      become: yes      
 
     - name: Install pexpect
       pip:
         name: pexpect  
+      become: yes  
 
     - name: Export config prysm
       include_role:

--- a/export-config.yaml
+++ b/export-config.yaml
@@ -35,6 +35,11 @@
         name: export-config-teku
       when: setup == "teku"
 
+    - name: Export config multiclient
+      include_role:
+        name: export-config-multiclient
+      when: setup == "multiclient"  
+
     - name: Create compressed archive of exported-config directory
       archive:
         path: /tmp/exported-config

--- a/export-config.yaml
+++ b/export-config.yaml
@@ -4,11 +4,47 @@
     - /etc/stereum/ethereum2.yaml
 
   tasks:
+    - name: Download age
+      get_url:
+        url: https://github.com/FiloSottile/age/releases/download/v1.0.0-rc.1/age-v1.0.0-rc.1-linux-amd64.tar.gz
+        dest: /tmp/age.gz
+        mode: '0655'
+      become: yes
+
+    - name: Extract '/tmp/age.gz' to '/usr/local/bin'
+      ansible.builtin.unarchive:
+        src: /tmp/age.gz
+        dest: /usr/local/bin
+      become: yes 
+
+    - name: Remove '/tmp/age.gz' file
+      ansible.builtin.file:
+        path: /tmp/age.gz
+        state: absent
+      become: yes  
+
     - name: Create directory for exporting config and keystore files
       ansible.builtin.file:
         path: /tmp/exported-config
         state: directory
       become: yes
+
+    - name: Create directory for exporting wallet and passphrases
+      ansible.builtin.file:
+        path: /tmp/exported-config/wallet
+        state: directory
+      become: yes  
+      when: setup == "multiclient"
+
+    - name: Install pip
+      apt:
+        update_cache: yes
+        name:
+          - python3-pip
+
+    - name: Install pexpect
+      pip:
+        name: pexpect  
 
     - name: Export config prysm
       include_role:
@@ -54,8 +90,10 @@
       become: yes  
 
     - name: Set exported config zip file's permission
-      command: "chmod -R 755 /tmp/exported-config.zip"
-      become: yes
+      ansible.builtin.file:
+        path: /tmp/exported-config.zip
+        mode: '755'
+      become: yes  
 
     - name: INFO
       debug:

--- a/import-validator-accounts.yaml
+++ b/import-validator-accounts.yaml
@@ -85,6 +85,12 @@
     - name: Checking keys' password of teku
       include_role:
         name: check-keys-password-teku
-      when: setup == "teku"  
+      when: setup == "teku" 
+
+    - name: Remove exported-config directory
+      file:
+        path: "/tmp/exported-config"
+        state: absent
+      when: validator_password is defined and exported_config_path is defined 
 
 # EOF  

--- a/import-validator-accounts.yaml
+++ b/import-validator-accounts.yaml
@@ -76,6 +76,7 @@
       file:
         path: "/tmp/exported-config"
         state: absent
+      become: yes  
       when: validator_password is defined and exported_config_path is defined 
 
 # EOF  

--- a/import-validator-accounts.yaml
+++ b/import-validator-accounts.yaml
@@ -6,12 +6,12 @@
   tasks:
     - name: call stop-services role
       include_role:
-        name: stop-services
+        name: stop-services   
 
     - name: Checking imported keys of teku
       include_role:
         name: check-imported-keys-teku
-      when: setup == "teku"
+      when: setup == "teku" and exported_config_path is not defined
 
     - name: Create validator keys
       copy:
@@ -19,12 +19,17 @@
         content: "{{ item.content }}"
       become: yes
       with_items: "{{validator_keys}}"
-      when: validator_keys is defined
+      when: validator_keys is defined 
 
     - name: Copy lanchpad wallet's validator keys
       shell: "cp {{ validator_keys_path }}/keystore-*.json {{ e2dc_install_path }}/launchpad"
       become: yes
-      when: setup != "multiclient" and validator_keys is not defined
+      when: setup != "multiclient" and validator_keys_path is defined
+
+    - name: Copy lanchpad wallet's validator keys 'config-import'
+      shell: "cp /tmp/exported-config/keystore-*.json {{ e2dc_install_path }}/launchpad"
+      become: yes
+      when: exported_config_path is defined and setup != "multiclient"
 
     - name: Set permissions of import folder
       shell: "chown -R {{ stereum_user }}:{{ stereum_user }} {{ e2dc_install_path }}/launchpad"
@@ -80,6 +85,6 @@
     - name: Checking keys' password of teku
       include_role:
         name: check-keys-password-teku
-      when: setup == "teku"
+      when: setup == "teku"  
 
 # EOF  

--- a/import-validator-accounts.yaml
+++ b/import-validator-accounts.yaml
@@ -6,35 +6,20 @@
   tasks:
     - name: call stop-services role
       include_role:
-        name: stop-services   
+        name: stop-services 
+
+    - name: Check - key files exists
+      include_role:
+        name: check-keys-exists   
 
     - name: Checking imported keys of teku
       include_role:
         name: check-imported-keys-teku
       when: setup == "teku" and exported_config_path is not defined
 
-    - name: Create validator keys
-      copy:
-        dest: "{{ e2dc_install_path }}/launchpad/{{ item.name }}"
-        content: "{{ item.content }}"
-      become: yes
-      with_items: "{{validator_keys}}"
-      when: validator_keys is defined 
-
-    - name: Copy lanchpad wallet's validator keys
-      shell: "cp {{ validator_keys_path }}/keystore-*.json {{ e2dc_install_path }}/launchpad"
-      become: yes
-      when: setup != "multiclient" and validator_keys_path is defined
-
-    - name: Copy lanchpad wallet's validator keys 'config-import'
-      shell: "cp /tmp/exported-config/keystore-*.json {{ e2dc_install_path }}/launchpad"
-      become: yes
-      when: exported_config_path is defined and setup != "multiclient"
-
-    - name: Set permissions of import folder
-      shell: "chown -R {{ stereum_user }}:{{ stereum_user }} {{ e2dc_install_path }}/launchpad"
-      become: yes
-      when: setup != "multiclient"
+    - name: Copy validator keys to launchpad directory
+      include_role:
+        name: copy-validator-keys-to-launchpad
 
     - block:
       - name: import to lighthouse

--- a/init-setup.yaml
+++ b/init-setup.yaml
@@ -14,5 +14,7 @@
       file: /etc/stereum/ethereum2.yaml
 
 - import_playbook: install.yaml
+- import_playbook: import-validator-accounts.yaml
+  when: exported_config_path is defined and validator_password is defined
 
 # EOF

--- a/roles/check-keys-exists/tasks/main.yaml
+++ b/roles/check-keys-exists/tasks/main.yaml
@@ -1,0 +1,40 @@
+---
+- name: Check validator keys exists CLI
+  find:
+    paths: "{{ validator_keys_path }}"
+    patterns: "keystore-*.json"
+  register: keystore_files
+  become: yes
+  when: setup != "multiclient" and validator_keys_path is defined
+
+- name: Error - No Validators found!
+  fail:
+    msg: "No validators found!"
+  when: ((setup != "multiclient" and validator_keys_path is defined) and keystore_files.matched < 1)    
+
+- name: Check validator keys exists 'import-config'
+  find:
+    paths: /tmp/exported-config
+    patterns: "keystore-*.json"
+  register: keystore_files
+  become: yes
+  when: setup != "multiclient" and exported_config_path is defined
+
+- name: Error - No Validators found!
+  fail:
+    msg: "No validators found!"
+  when: ((setup != "multiclient" and exported_config_path is defined) and keystore_files.matched < 1)  
+
+- name: Check wallet exists multiclient 'import-config'
+  find:
+    paths: /tmp/exported-config/wallet/
+  register: wallet
+  become: yes
+  when: setup == "multiclient" and exported_config_path is defined  
+
+- name: Error - No Wallet found!
+  fail:
+    msg: "No Wallet found!"
+  when: ((setup == "multiclient" and exported_config_path is defined) and wallet.examined < 1)
+
+# EOF  

--- a/roles/check-keys-password-teku/tasks/main.yaml
+++ b/roles/check-keys-password-teku/tasks/main.yaml
@@ -43,6 +43,16 @@
   with_items: '{{importing_key_cli.stdout_lines}}'
   when: validator_keys is not defined and (validator_log.stdout is search('Failed to decrypt keystore') or validator_log.stdout is search('Keystore password cannot be empty'))
 
+- name: Remove keystores files from launchpad 'import-config'
+  shell: rm "{{ e2dc_install_path }}/launchpad/*.json"
+  become: yes
+  when: exported_config_path is defined and (validator_log.stdout is search('Failed to decrypt keystore') or validator_log.stdout is search('Keystore password cannot be empty'))
+
+- name: Remove password files from launchpad 'import-config'
+  shell: rm "{{ e2dc_install_path }}/launchpad/*.txt"
+  become: yes
+  when: exported_config_path is defined and (validator_log.stdout is search('Failed to decrypt keystore') or validator_log.stdout is search('Keystore password cannot be empty'))  
+
 - fail:
     msg: 'Incorrect password for account'
   become: yes

--- a/roles/check-keys-password-teku/tasks/main.yaml
+++ b/roles/check-keys-password-teku/tasks/main.yaml
@@ -44,14 +44,22 @@
   when: validator_keys is not defined and (validator_log.stdout is search('Failed to decrypt keystore') or validator_log.stdout is search('Keystore password cannot be empty'))
 
 - name: Remove keystores files from launchpad 'import-config'
-  shell: rm "{{ e2dc_install_path }}/launchpad/*.json"
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/*.json"
   become: yes
   when: exported_config_path is defined and (validator_log.stdout is search('Failed to decrypt keystore') or validator_log.stdout is search('Keystore password cannot be empty'))
 
 - name: Remove password files from launchpad 'import-config'
-  shell: rm "{{ e2dc_install_path }}/launchpad/*.txt"
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/*.txt"
   become: yes
-  when: exported_config_path is defined and (validator_log.stdout is search('Failed to decrypt keystore') or validator_log.stdout is search('Keystore password cannot be empty'))  
+  when: exported_config_path is defined and (validator_log.stdout is search('Failed to decrypt keystore') or validator_log.stdout is search('Keystore password cannot be empty'))
 
 - fail:
     msg: 'Incorrect password for account'

--- a/roles/copy-validator-keys-to-launchpad/tasks/main.yaml
+++ b/roles/copy-validator-keys-to-launchpad/tasks/main.yaml
@@ -1,0 +1,40 @@
+---
+- name: Create validator keys WEB
+  copy:
+    dest: "{{ e2dc_install_path }}/launchpad/{{ item.name }}"
+    content: "{{ item.content }}"
+  become: yes
+  with_items: "{{validator_keys}}"
+  when: validator_keys is defined
+
+- name: Copy lanchpad wallet's validator keys CLI
+  copy:
+    src: "{{ item }}"
+    dest: "{{ e2dc_install_path }}/launchpad"
+    mode: '0755'
+  with_fileglob:
+    - "{{ validator_keys_path }}/keystore-*.json"
+  become: yes
+  when: setup != "multiclient" and validator_keys_path is defined
+
+- name: Copy lanchpad wallet's validator keys 'config-import'
+  copy:
+    src: "{{ item }}"
+    dest: "{{ e2dc_install_path }}/launchpad"
+    mode: '0755'
+  with_fileglob:
+    - "/tmp/exported-config/keystore-*.json"
+  become: yes
+  when: setup != "multiclient" and exported_config_path is defined
+
+- name: Set launchpad dir's permission
+  ansible.builtin.file:
+    path: "{{ e2dc_install_path }}/launchpad"
+    owner: "{{ stereum_user }}"
+    group: "{{ stereum_user }}"
+    recurse: true
+    mode: '0755'
+  become: yes
+  when: setup != "multiclient"
+
+# EOF  

--- a/roles/export-config-lighthouse/tasks/main.yaml
+++ b/roles/export-config-lighthouse/tasks/main.yaml
@@ -1,16 +1,27 @@
 ---
 - name: Export config - ethereum2.yaml file
-  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
-  args:
-    chdir: "/etc/stereum/"
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/exported_config.age /etc/stereum/ethereum2.yaml
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ export_config_password | quote }}"
+       Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Export keystore files
-  shell: "cp {{ e2dc_install_path }}/launchpad/keystore_backup/keystore-*.json /tmp/exported-config"
+- name: Change file ownership, group and permissions
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config
+    mode: '0755'
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore_backup/keystore-*.json"
   become: yes
 
-- name: Set exported config file's permission
-  command: "chmod -R 755 /tmp/exported-config"
+- name: Set exported config dir's permission
+  ansible.builtin.file:
+    path: /tmp/exported-config
+    mode: '755'
+    recurse: yes
   become: yes
 
 # EOF

--- a/roles/export-config-lighthouse/tasks/main.yaml
+++ b/roles/export-config-lighthouse/tasks/main.yaml
@@ -8,7 +8,7 @@
        Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Change file ownership, group and permissions
+- name: Export keystore files
   copy:
     src: "{{ item }}"
     dest: /tmp/exported-config

--- a/roles/export-config-lodestar/tasks/main.yaml
+++ b/roles/export-config-lodestar/tasks/main.yaml
@@ -1,16 +1,27 @@
 ---
 - name: Export config - ethereum2.yaml file
-  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
-  args:
-    chdir: "/etc/stereum/"
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/exported_config.age /etc/stereum/ethereum2.yaml
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ export_config_password | quote }}"
+       Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Export keystore files
-  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config"
+- name: Change file ownership, group and permissions
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config
+    mode: '0755'
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
   become: yes
 
-- name: Set exported config file's permission
-  command: "chmod -R 755 /tmp/exported-config"
+- name: Set exported config dir's permission
+  ansible.builtin.file:
+    path: /tmp/exported-config
+    mode: '755'
+    recurse: yes
   become: yes
 
 # EOF

--- a/roles/export-config-lodestar/tasks/main.yaml
+++ b/roles/export-config-lodestar/tasks/main.yaml
@@ -8,7 +8,7 @@
        Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Change file ownership, group and permissions
+- name: Export keystore files
   copy:
     src: "{{ item }}"
     dest: /tmp/exported-config

--- a/roles/export-config-multiclient/tasks/main.yaml
+++ b/roles/export-config-multiclient/tasks/main.yaml
@@ -29,7 +29,7 @@
     format: gz
   become: yes  
 
-- name: Encrypt wallet.zip file
+- name: Encrypt wallet.gz file
   ansible.builtin.expect:
   command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/wallet.age /tmp/exported-config/wallet.gz
   timeout: "300"

--- a/roles/export-config-multiclient/tasks/main.yaml
+++ b/roles/export-config-multiclient/tasks/main.yaml
@@ -1,0 +1,12 @@
+---
+- name: Export config - ethereum2.yaml file
+  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
+  args:
+    chdir: "/etc/stereum/"
+  become: yes
+
+- name: Set exported config file's permission
+  command: "chmod -R 755 /tmp/exported-config"
+  become: yes
+
+# EOF

--- a/roles/export-config-multiclient/tasks/main.yaml
+++ b/roles/export-config-multiclient/tasks/main.yaml
@@ -27,6 +27,7 @@
     path: /tmp/exported-config/wallet
     dest: /tmp/exported-config/wallet.zip
     format: zip
+    directory_mode: yes
   become: yes  
 
 - name: Encrypt wallet.zip file

--- a/roles/export-config-multiclient/tasks/main.yaml
+++ b/roles/export-config-multiclient/tasks/main.yaml
@@ -1,12 +1,57 @@
 ---
 - name: Export config - ethereum2.yaml file
-  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
-  args:
-    chdir: "/etc/stereum/"
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/exported_config.age /etc/stereum/ethereum2.yaml
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ export_config_password | quote }}"
+       Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Set exported config file's permission
-  command: "chmod -R 755 /tmp/exported-config"
+- name: Export ethdo wallet
+  ansible.builtin.copy:
+    src: "{{ e2dc_install_path }}/wallets/"
+    dest: /tmp/exported-config/wallet
+    mode: '0755'
+  become: yes  
+
+- name: Export wallet's passphrases 
+  ansible.builtin.copy:
+    src: "{{ e2dc_install_path }}/config/dirk/passphrases/"
+    dest: /tmp/exported-config/wallet
+    mode: '0755'
+  become: yes  
+
+- name: Create compressed archive of wallet directory
+  archive:
+    path: /tmp/exported-config/wallet
+    dest: /tmp/exported-config/wallet.zip
+    format: zip
+  become: yes  
+
+- name: Encrypt wallet.zip file
+  ansible.builtin.expect:
+  command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/wallet.age /tmp/exported-config/wallet.zip
+  timeout: "300"
+  responses:
+     Enter passphrase: "{{ export_config_password | quote }}"
+     Confirm passphrase: "{{ export_config_password | quote }}"
+  become: yes  
+
+- name: Remove wallet directory
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  with_items: 
+    - /tmp/exported-config/wallet
+    - /tmp/exported-config/wallet.zip
+  become: yes  
+
+- name: Set exported config dir's permission
+  ansible.builtin.file:
+    path: /tmp/exported-config
+    mode: '755'
+    recurse: yes
   become: yes
 
 # EOF

--- a/roles/export-config-multiclient/tasks/main.yaml
+++ b/roles/export-config-multiclient/tasks/main.yaml
@@ -25,14 +25,13 @@
 - name: Create compressed archive of wallet directory
   archive:
     path: /tmp/exported-config/wallet
-    dest: /tmp/exported-config/wallet.zip
-    format: zip
-    directory_mode: yes
+    dest: /tmp/exported-config/wallet.gz
+    format: gz
   become: yes  
 
 - name: Encrypt wallet.zip file
   ansible.builtin.expect:
-  command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/wallet.age /tmp/exported-config/wallet.zip
+  command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/wallet.age /tmp/exported-config/wallet.gz
   timeout: "300"
   responses:
      Enter passphrase: "{{ export_config_password | quote }}"
@@ -45,7 +44,7 @@
     state: absent
   with_items: 
     - /tmp/exported-config/wallet
-    - /tmp/exported-config/wallet.zip
+    - /tmp/exported-config/wallet.gz
   become: yes  
 
 - name: Set exported config dir's permission

--- a/roles/export-config-nimbus/tasks/main.yaml
+++ b/roles/export-config-nimbus/tasks/main.yaml
@@ -1,16 +1,27 @@
 ---
 - name: Export config - ethereum2.yaml file
-  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
-  args:
-    chdir: "/etc/stereum/"
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/exported_config.age /etc/stereum/ethereum2.yaml
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ export_config_password | quote }}"
+       Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Export keystore files
-  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config"
+- name: Change file ownership, group and permissions
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config
+    mode: '0755'
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
   become: yes
 
-- name: Set exported config file's permission
-  command: "chmod -R 755 /tmp/exported-config"
+- name: Set exported config dir's permission
+  ansible.builtin.file:
+    path: /tmp/exported-config
+    mode: '755'
+    recurse: yes
   become: yes
 
 # EOF

--- a/roles/export-config-nimbus/tasks/main.yaml
+++ b/roles/export-config-nimbus/tasks/main.yaml
@@ -8,7 +8,7 @@
        Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Change file ownership, group and permissions
+- name: Export keystore files
   copy:
     src: "{{ item }}"
     dest: /tmp/exported-config

--- a/roles/export-config-prysm/tasks/main.yaml
+++ b/roles/export-config-prysm/tasks/main.yaml
@@ -1,16 +1,27 @@
 ---
 - name: Export config - ethereum2.yaml file
-  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
-  args:
-    chdir: "/etc/stereum/"
-  become: yes
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/exported_config.age /etc/stereum/ethereum2.yaml
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ export_config_password | quote }}"
+       Confirm passphrase: "{{ export_config_password | quote }}"
+  become: yes  
 
-- name: Export keystore files
-  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config"
-  become: yes
+- name: Change file ownership, group and permissions
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config
+    mode: '0755'
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  become: yes  
 
-- name: Set exported config file's permission
-  command: "chmod -R 755 /tmp/exported-config"
+- name: Set exported config dir's permission
+  ansible.builtin.file:
+    path: /tmp/exported-config
+    mode: '755'
+    recurse: yes
   become: yes
 
 # EOF

--- a/roles/export-config-prysm/tasks/main.yaml
+++ b/roles/export-config-prysm/tasks/main.yaml
@@ -8,7 +8,7 @@
        Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes  
 
-- name: Change file ownership, group and permissions
+- name: Export keystore files
   copy:
     src: "{{ item }}"
     dest: /tmp/exported-config

--- a/roles/export-config-teku/tasks/main.yaml
+++ b/roles/export-config-teku/tasks/main.yaml
@@ -1,16 +1,27 @@
 ---
 - name: Export config - ethereum2.yaml file
-  shell: echo "{{ export_config_password | quote }}" | gpg -c --output /tmp/exported-config/exported_config.gpg --batch --yes --passphrase-fd 0 ethereum2.yaml
-  args:
-    chdir: "/etc/stereum/"
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -e -p --output /tmp/exported-config/exported_config.age /etc/stereum/ethereum2.yaml
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ export_config_password | quote }}"
+       Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Export keystore files
-  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json /tmp/exported-config"
+- name: Change file ownership, group and permissions
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config
+    mode: '0755'
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
   become: yes
 
-- name: Set exported config file's permission
-  command: "chmod -R 755 /tmp/exported-config"
+- name: Set exported config dir's permission
+  ansible.builtin.file:
+    path: /tmp/exported-config
+    mode: '755'
+    recurse: yes
   become: yes
 
-# EOF
+# EOF 

--- a/roles/export-config-teku/tasks/main.yaml
+++ b/roles/export-config-teku/tasks/main.yaml
@@ -8,7 +8,7 @@
        Confirm passphrase: "{{ export_config_password | quote }}"
   become: yes
 
-- name: Change file ownership, group and permissions
+- name: Export keystore files
   copy:
     src: "{{ item }}"
     dest: /tmp/exported-config

--- a/roles/import-config/tasks/main.yaml
+++ b/roles/import-config/tasks/main.yaml
@@ -4,30 +4,88 @@
     name: unzip
     update_cache: yes
 
-- name: Unarchive exported-config.zip file
+- name: Download age
+  get_url:
+    url: https://github.com/FiloSottile/age/releases/download/v1.0.0-rc.1/age-v1.0.0-rc.1-linux-amd64.tar.gz
+    dest: /tmp/age.gz
+    mode: '0655'
+  become: yes
+
+- name: Extract '/tmp/age.gz' to '/usr/local/bin'
+  ansible.builtin.unarchive:
+    src: /tmp/age.gz
+    dest: /usr/local/bin
+  become: yes
+
+- name: Remove '/tmp/age.gz' file
+  ansible.builtin.file:
+    path: /tmp/age.gz
+    state: absent
+  become: yes    
+
+- name: Unzip exported-config.zip file
   ansible.builtin.unarchive:
     src: "{{ exported_config_path }}"
     dest: /tmp
     remote_src: yes
   become: yes
 
-- name: Decrypt configuration file
-  shell: echo "{{ exported_config_password | quote }}" | gpg -d --output /tmp/exported-config/ethereum2.yaml --batch --yes --passphrase-fd 0 /tmp/exported-config/exported_config.gpg
-  args:
-    chdir: "/tmp/exported-config"
-  become: yes
+- name: Decrypt exported-config.age file
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -d --output /tmp/exported-config/ethereum2.yaml /tmp/exported-config/exported_config.age
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ exported_config_password | quote }}"
+  become: yes  
 
-- name: Set permission to config-file
-  shell: "chmod -R 755 /tmp/exported-config"
-  args:
-    warn: false
+- name: Decrypt wallet.age file
+  ansible.builtin.expect:
+    command: /usr/local/bin/age/age -d --output /tmp/exported-config/wallet.gz /tmp/exported-config/wallet.age
+    timeout: "300"
+    responses:
+       Enter passphrase: "{{ exported_config_password | quote }}"
   become: yes
+  when: setup == "multiclient"
+
+- name: Unarchive wallet.gz
+  ansible.builtin.unarchive:
+    src: /tmp/exported-config/wallet.gz
+    dest: /tmp/exported-config
+  become: yes
+  when: setup == "multiclient"
+
+- name: Copy password files into exported-config directory
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /tmp/exported-config
+    mode: '0755'
+  with_fileglob:
+    - "/tmp/exported-config/wallet/*-passphrase.txt"  
+  become: yes
+  when: setup == "multiclient"
+
+- name: Remove password files from wallet dir
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_fileglob:
+    - "/tmp/exported-config/wallet/*-passphrase.txt"  
+  become: yes
+  when: setup == "multiclient"     
+
+- name: Set exported-config dir's permission
+  ansible.builtin.file:
+    path: /tmp/exported-config
+    mode: '755'
+    recurse: yes
+  become: yes  
 
 - name: Write imported config file
-  shell: "cp /tmp/exported-config/ethereum2.yaml /etc/stereum"
-  args:
-    warn: false
-  become: yes
+  ansible.builtin.copy:
+    src: /tmp/exported-config/ethereum2.yaml
+    dest: /etc/stereum
+    mode: '0755'
+  become: yes  
 
 - name: Remove exported-config directory
   file: 

--- a/roles/import-config/tasks/main.yaml
+++ b/roles/import-config/tasks/main.yaml
@@ -29,4 +29,10 @@
     warn: false
   become: yes
 
+- name: Remove exported-config directory
+  file: 
+    path: "/tmp/exported-config" 
+    state: absent
+  when: validator_password is not defined
+
 # EOF      

--- a/roles/import-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/import-validator-keys-lighthouse/tasks/main.yaml
@@ -58,8 +58,13 @@
   become: yes
 
 - name: Copy keystore files to backup directory
-  shell: "cp {{ e2dc_install_path }}/launchpad/keystore-*.json {{ e2dc_install_path }}/launchpad/keystore_backup"
-  become: yes  
+  copy:
+    src: "{{ item }}"
+    dest: "{{ e2dc_install_path }}/launchpad/keystore_backup"
+    mode: '0755'
+  with_fileglob:
+    - "{{ e2dc_install_path }}/launchpad/keystore-*.json"
+  become: yes
 
 - name: Removing keys from launchpad
   file:

--- a/roles/import-validator-keys-lighthouse/tasks/main.yaml
+++ b/roles/import-validator-keys-lighthouse/tasks/main.yaml
@@ -19,20 +19,21 @@
   command: "cat {{ e2dc_install_path }}/wallets/validators/validator_definitions.yml"
   register: definition_content
   become: yes
+  when: exported_config_path is not defined
 
 - name: Remove validator_definition if it is empty
   file:
     path: "{{ e2dc_install_path }}/wallets/validators/validator_definitions.yml"
     state: absent
   become: yes
-  when: "{{ definition_content.stdout_lines | length < 3 }}"
+  when: "{{ definition_content.stdout_lines | length < 3 }}" and exported_config_path is not defined
 
 - name: Remove api-token file if no validators imported
   file:
     path: "{{ e2dc_install_path }}/wallets/validators/api-token.txt"
     state: absent
   become: yes
-  when: "{{ definition_content.stdout_lines | length < 3 }}"  
+  when: "{{ definition_content.stdout_lines | length < 3 }}" and exported_config_path is not defined 
 
 - name: Run import
   shell: "./lighthouse_validator_import.sh {{ validator_password | quote }}"

--- a/roles/import-validator-keys-multiclient/tasks/main.yaml
+++ b/roles/import-validator-keys-multiclient/tasks/main.yaml
@@ -83,9 +83,13 @@
   become: yes 
 
 - name: Copy wallet into Stereum's wallets directory
-  command: "cp -r ~/.config/ethereum2/wallets/. {{ e2dc_install_path }}/wallets"
-  args:
-    warn: false
+  ansible.builtin.copy:
+    src: ~/.config/ethereum2/wallets/
+    dest: "{{ e2dc_install_path }}/wallets"
+    owner: stereum
+    group: stereum
+    mode: '0755'
+  become: yes    
 
 - name: Put the account password into the Dirk passphrases
   ansible.builtin.copy:

--- a/roles/import-validator-keys-multiclient/tasks/main.yaml
+++ b/roles/import-validator-keys-multiclient/tasks/main.yaml
@@ -13,7 +13,8 @@
 
 - name: Install pexpect
   pip:
-    name: pexpect     
+    name: pexpect
+  become: yes    
   when: validator_number is defined and validator_mnemonic is defined  
 
 - name: Find out home directory

--- a/roles/import-validator-keys-multiclient/tasks/main.yaml
+++ b/roles/import-validator-keys-multiclient/tasks/main.yaml
@@ -14,15 +14,18 @@
 - name: Install pexpect
   pip:
     name: pexpect     
+  when: validator_number is defined and validator_mnemonic is defined  
 
 - name: Find out home directory
   command: echo $HOME
   register: homedir
+  when: validator_number is defined and validator_mnemonic is defined
 
 - name: Checking Go is already installed
   stat: 
     path: "{{ homedir.stdout}}/go"
   register: go_check
+  when: validator_number is defined and validator_mnemonic is defined
 
 - name: Remove other version of Go if installed
   ansible.builtin.expect:
@@ -30,19 +33,20 @@
     timeout: 10
     responses:
        'Do you want to continue?': "y"
-  when: go_check.stat.exists and go_check.stat.isdir
+  when: (go_check.stat.exists and go_check.stat.isdir) and validator_mnemonic is defined
 
 - name: Remove Go directory if exists
   ansible.builtin.file:
     path: "{{ homedir.stdout }}/go"
     state: absent
-  when: go_check.stat.exists and go_check.stat.isdir
+  when: (go_check.stat.exists and go_check.stat.isdir) and validator_mnemonic is defined
 
 - name: Download and Extract Go binary in '$HOME'
   shell: wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C "{{ homedir.stdout }}"
   args:
     warn: false
   become: yes
+  when: validator_number is defined and validator_mnemonic is defined
 
 - name: Add GO PATH in '$HOME/.profile'
   blockinfile:
@@ -50,7 +54,8 @@
     block: |
       if [ -d "{{ homedir.stdout }}/go/bin" ] ; then
         PATH="$PATH:{{ homedir.stdout }}/go/bin"
-      fi
+      fi 
+  when: validator_number is defined and validator_mnemonic is defined    
 
 - name: Source .profile
   shell: "{{ item }}"
@@ -58,17 +63,21 @@
     - source ~/.profile
   args:
     executable: /bin/bash
+  when: validator_number is defined and validator_mnemonic is defined  
 
 - name: Install ethdo
   shell:
-    cmd: GO111MODULE=on "{{ homedir.stdout }}/go/bin/go" get github.com/wealdtech/ethdo  
+    cmd: GO111MODULE=on "{{ homedir.stdout }}/go/bin/go" get github.com/wealdtech/ethdo 
+  when: validator_number is defined and validator_mnemonic is defined   
 
 - name: Generate password for wallet and account
   shell: uuidgen
   register: password_gen  
+  when: validator_number is defined and validator_mnemonic is defined
 
 - name: create ethdo wallet
   shell: ~/go/bin/ethdo wallet create --type=hd --mnemonic= "{{ validator_mnemonic }}" --wallet="Wallet" --wallet-passphrase="{{password_gen.stdout}}"
+  when: validator_number is defined and validator_mnemonic is defined
   
 - name: create account(s)
   shell: |
@@ -81,15 +90,27 @@
   args:
     executable: /bin/bash  
   become: yes 
+  when: validator_number is defined and validator_mnemonic is defined
 
 - name: Copy wallet into Stereum's wallets directory
   ansible.builtin.copy:
     src: ~/.config/ethereum2/wallets/
     dest: "{{ e2dc_install_path }}/wallets"
-    owner: stereum
-    group: stereum
+    owner: "{{ stereum_user }}"
+    group: "{{ stereum_user }}"
     mode: '0755'
-  become: yes    
+  become: yes
+  when: validator_number is defined and validator_mnemonic is defined  
+
+- name: Copy wallet into Stereum's wallets directory 'import-config'
+  ansible.builtin.copy:
+    src: /tmp/exported-config/wallet/
+    dest: "{{ e2dc_install_path }}/wallets"
+    owner: "{{ stereum_user }}"
+    group: "{{ stereum_user }}"
+    mode: '0755'
+  become: yes  
+  when: exported_config_path is defined and exported_config_password is defined
 
 - name: Put the account password into the Dirk passphrases
   ansible.builtin.copy:
@@ -97,6 +118,15 @@
     dest: "{{ e2dc_install_path }}/config/dirk/passphrases/account-passphrase.txt"
   become: yes
   become_user: "{{ stereum_user }}"
+  when: validator_number is defined and validator_mnemonic is defined
+
+- name: Put the account password into the Dirk passphrases 'import-config'
+  ansible.builtin.copy:
+    src: /tmp/exported-config/account-passphrase.txt
+    dest: "{{ e2dc_install_path }}/config/dirk/passphrases/account-passphrase.txt"
+    mode: '0755'
+  become: yes  
+  when: exported_config_path is defined and exported_config_password is defined
 
 - name: Put the wallet password into the Dirk passphrases
   ansible.builtin.copy:
@@ -104,6 +134,15 @@
     dest: "{{ e2dc_install_path }}/config/dirk/passphrases/wallet-passphrase.txt"
   become: yes
   become_user: "{{ stereum_user }}"
+  when: validator_number is defined and validator_mnemonic is defined
+
+- name: Put the wallet password into the Dirk passphrases 'import-config'
+  ansible.builtin.copy:
+    src: /tmp/exported-config/wallet-passphrase.txt
+    dest: "{{ e2dc_install_path }}/config/dirk/passphrases/wallet-passphrase.txt"
+    mode: '0755'
+  become: yes
+  when: exported_config_path is defined and exported_config_password is defined  
 
 - name: Put the wallet name into the Vouch
   ansible.builtin.replace:

--- a/roles/import-validator-keys-multiclient/tasks/main.yaml
+++ b/roles/import-validator-keys-multiclient/tasks/main.yaml
@@ -8,10 +8,60 @@
     - git
     - build-essential
     - gcc
-    - golang
+    - wget
+    - python3-pip  
+
+- name: Install pexpect
+  pip:
+    name: pexpect     
+
+- name: Find out home directory
+  command: echo $HOME
+  register: homedir
+
+- name: Checking Go is already installed
+  stat: 
+    path: "{{ homedir.stdout}}/go"
+  register: go_check
+
+- name: Remove other version of Go if installed
+  ansible.builtin.expect:
+    command: "apt-get remove --auto-remove golang-go"
+    timeout: 10
+    responses:
+       'Do you want to continue?': "y"
+  when: go_check.stat.exists and go_check.stat.isdir
+
+- name: Remove Go directory if exists
+  ansible.builtin.file:
+    path: "{{ homedir.stdout }}/go"
+    state: absent
+  when: go_check.stat.exists and go_check.stat.isdir
+
+- name: Download and Extract Go binary in '$HOME'
+  shell: wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C "{{ homedir.stdout }}"
+  args:
+    warn: false
+  become: yes
+
+- name: Add GO PATH in '$HOME/.profile'
+  blockinfile:
+    path: ~/.profile
+    block: |
+      if [ -d "{{ homedir.stdout }}/go/bin" ] ; then
+        PATH="$PATH:{{ homedir.stdout }}/go/bin"
+      fi
+
+- name: Source .profile
+  shell: "{{ item }}"
+  with_items:
+    - source ~/.profile
+  args:
+    executable: /bin/bash
 
 - name: Install ethdo
-  shell: GO111MODULE=on go get github.com/wealdtech/ethdo
+  shell:
+    cmd: GO111MODULE=on "{{ homedir.stdout }}/go/bin/go" get github.com/wealdtech/ethdo  
 
 - name: Generate password for wallet and account
   shell: uuidgen
@@ -29,14 +79,13 @@
     ((i=i+1))
     done
   args:
-    executable: /bin/bash
+    executable: /bin/bash  
+  become: yes 
 
 - name: Copy wallet into Stereum's wallets directory
-  command: cp -r ~/.config/ethereum2/wallets/. {{ e2dc_install_path }}/wallets
-  become: yes
-
-- name: Set permissions of wallet directory
-  shell: "chown -R {{ stereum_user }}:{{ stereum_user }} {{ e2dc_install_path }}/wallets"
+  command: "cp -r ~/.config/ethereum2/wallets/. {{ e2dc_install_path }}/wallets"
+  args:
+    warn: false
 
 - name: Put the account password into the Dirk passphrases
   ansible.builtin.copy:
@@ -60,3 +109,4 @@
   become: yes
   become_user: "{{ stereum_user }}"
 
+# EOF

--- a/roles/import-validator-keys-prysm/tasks/main.yaml
+++ b/roles/import-validator-keys-prysm/tasks/main.yaml
@@ -15,7 +15,7 @@
     state: latest
   when: ansible_distribution == "CentOS"
 
-- name: get existing wallet password
+- name: Get existing wallet password
   command: "cat {{ e2dc_install_path }}/data/prysm/validator/passwords/wallet-password"
   register: existing_password
   ignore_errors: yes

--- a/roles/start-services/tasks/main.yaml
+++ b/roles/start-services/tasks/main.yaml
@@ -5,10 +5,5 @@
     chdir: "{{ e2dc_install_path }}"
   become: yes
   become_user: "{{ stereum_user }}"
-  when: setup != "multiclient"
 
-- name: Start services multiclient
-  shell: "./edc-up.sh"
-  args:
-    chdir: "{{ e2dc_install_path }}"
-  when: setup == "multiclient"  
+# EOF  

--- a/roles/start-services/tasks/main.yaml
+++ b/roles/start-services/tasks/main.yaml
@@ -5,3 +5,10 @@
     chdir: "{{ e2dc_install_path }}"
   become: yes
   become_user: "{{ stereum_user }}"
+  when: setup != "multiclient"
+
+- name: Start services multiclient
+  shell: "./edc-up.sh"
+  args:
+    chdir: "{{ e2dc_install_path }}"
+  when: setup == "multiclient"  

--- a/roles/stop-services/tasks/main.yaml
+++ b/roles/stop-services/tasks/main.yaml
@@ -5,10 +5,5 @@
     chdir: "{{ e2dc_install_path }}"
   become: yes
   become_user: "{{ stereum_user }}"
-  when: setup != "multiclient"
 
-- name: Stop services
-  shell: "./edc-stop.sh"
-  args:
-    chdir: "{{ e2dc_install_path }}"
-  when: setup == "multiclient"  
+# EOF  

--- a/roles/stop-services/tasks/main.yaml
+++ b/roles/stop-services/tasks/main.yaml
@@ -5,3 +5,10 @@
     chdir: "{{ e2dc_install_path }}"
   become: yes
   become_user: "{{ stereum_user }}"
+  when: setup != "multiclient"
+
+- name: Stop services
+  shell: "./edc-stop.sh"
+  args:
+    chdir: "{{ e2dc_install_path }}"
+  when: setup == "multiclient"  


### PR DESCRIPTION
https://github.com/stereum-dev/ethereum2-control-center-web/issues/76
- also multiclient's config-export & import (without validators)
- other clients import-config with validators (validators not tested yet) 
- Age encryption tool is used to export-and import configuration file ( instead GPG ) - https://github.com/stereum-dev/sba-audit-2021/issues/3
- importing configuration with Validators for all Clients

