### PR TITLE
Improve ssh ports detection and allow to use multiple ports

### DIFF
--- a/roles/configure-os-security/tasks/ufw.yaml
+++ b/roles/configure-os-security/tasks/ufw.yaml
@@ -1,17 +1,18 @@
 ---
-- name: read ssh port
-  shell: "grep ^Port /etc/ssh/sshd_config | tr -dc '0-9'"
-  register: grep_ssh_port
+- name: read ssh ports
+  shell: /usr/sbin/sshd -T|awk '/^port|listenaddress\s/ {num = split($2, arr, ":"); print arr[num]}'|sort -u
+  register: ssh_ports_config
 
-- name: set fact ssh port
+- name: set fact ssh ports
   set_fact:
-    common_ssh_port: "{{ grep_ssh_port.stdout }}"
-  when: grep_ssh_port.stdout|length > 0
+    common_ssh_ports: "{{ ssh_ports_config.stdout_lines }}"
+  when: ssh_ports_config.stdout_lines|length > 0
 
-- name: set fact ssh port
+- name: set fact ssh ports
   set_fact:
-    common_ssh_port: 22
-  when: grep_ssh_port.stdout|length == 0
+    common_ssh_ports:
+      - "22"
+  when: ssh_ports_config.stdout|length == 0
 
 - name: ufw deny incoming
   ufw:
@@ -25,8 +26,9 @@
   ufw:
     direction: in
     rule: allow
-    port: "{{ common_ssh_port | string }}"
+    port: "{{ item }}"
     proto: tcp
+  with_items: "{{ common_ssh_ports }}"
   environment:
     PATH: /sbin:{{ ansible_env.PATH }}
 


### PR DESCRIPTION
Ssh port number could be specified not only with "Port" directive, but also "ListenAddress".
The sshd_config could be split into many files by using "Include" directive. To avoid parsing all of them manually, it seems easier to just ask sshd to do it.
Sshd could listen on many ports.

This patch includes all of above cases.